### PR TITLE
Kubernetes intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+kubernetes-intro/hipster/frontend

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea
-kubernetes-intro/hipster/frontend

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# ashuvd_platform
-ashuvd Platform repository
+# Выполнено ДЗ №1
+
+- [ ] Основное ДЗ
+- [ ] Задание со *
+
+## В процессе сделано:
+- Разобрался почему все pod в namespace kube-system восстановились после удаления
+Поды etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube, kube-scheduler-minikube являются static pods и управляются kubelet на определенных нодах. Манифесты лежат /etc/kubernetes/manifests и перезапускаются они в случае сбоя или удаления по этим манифестам с помощью kubelet.
+Как я понял эти правила перезапуска зашиты записаны в этих манифестах. Посмотреть их можно зайдя в minikube ssh.
+Поды core-dns и kube-proxy поднимаются из манифестов которые лежат в etcd и соответственно поднимаются после etcd
+- Создал Dockerfile, создал образ на базе nginx
+- Создал манифест пода web, поднял под в котором 2 контейнера - основной и init и сделал между ними volume чтобы index.html попал в основной контейнер - и после подключения volume то содержимое папки которое я добавлял (homework.html) пропало, ну потому что теперь мы ссылаемся на volume. Как сделать так чтобы и volume был и то что лежало в app сохранилось ???
+Проверил работоспособность, получил index.html.
+- Склонировал frontend HipsterShop https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/frontend 
+- Создал образ на базе nginx (за основу взял Dockerfile для web)
+- Выполнил задание со *

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,111 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      serviceAccountName: default
+      containers:
+        - name: server
+          image: ashuvduddits/frontend2
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8000
+              httpHeaders:
+                - name: "Cookie"
+                  value: "shop_session-id=x-readiness-probe"
+          livenessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8000
+              httpHeaders:
+                - name: "Cookie"
+                  value: "shop_session-id=x-liveness-probe"
+          env:
+            - name: PORT
+              value: "8000"
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: "productcatalogservice:3550"
+            - name: CURRENCY_SERVICE_ADDR
+              value: "currencyservice:7000"
+            - name: CART_SERVICE_ADDR
+              value: "cartservice:7070"
+            - name: RECOMMENDATION_SERVICE_ADDR
+              value: "recommendationservice:8080"
+            - name: SHIPPING_SERVICE_ADDR
+              value: "shippingservice:50051"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkoutservice:5050"
+            - name: AD_SERVICE_ADDR
+              value: "adservice:9555"
+            # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+            # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
+            # - name: ENV_PLATFORM
+            #   value: "aws"
+            - name: DISABLE_TRACING
+              value: "1"
+            - name: DISABLE_PROFILER
+              value: "1"
+          # - name: CYMBAL_BRANDING
+          #   value: "true"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,111 +1,30 @@
-# Copyright 2018 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Pod
 metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
   name: frontend
 spec:
-  selector:
-    matchLabels:
-      app: frontend
-  template:
-    metadata:
-      labels:
-        app: frontend
-      annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
-    spec:
-      serviceAccountName: default
-      containers:
-        - name: server
-          image: ashuvduddits/frontend2
-          ports:
-            - containerPort: 8000
-          readinessProbe:
-            initialDelaySeconds: 10
-            httpGet:
-              path: "/_healthz"
-              port: 8000
-              httpHeaders:
-                - name: "Cookie"
-                  value: "shop_session-id=x-readiness-probe"
-          livenessProbe:
-            initialDelaySeconds: 10
-            httpGet:
-              path: "/_healthz"
-              port: 8000
-              httpHeaders:
-                - name: "Cookie"
-                  value: "shop_session-id=x-liveness-probe"
-          env:
-            - name: PORT
-              value: "8000"
-            - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: "productcatalogservice:3550"
-            - name: CURRENCY_SERVICE_ADDR
-              value: "currencyservice:7000"
-            - name: CART_SERVICE_ADDR
-              value: "cartservice:7070"
-            - name: RECOMMENDATION_SERVICE_ADDR
-              value: "recommendationservice:8080"
-            - name: SHIPPING_SERVICE_ADDR
-              value: "shippingservice:50051"
-            - name: CHECKOUT_SERVICE_ADDR
-              value: "checkoutservice:5050"
-            - name: AD_SERVICE_ADDR
-              value: "adservice:9555"
-            # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
-            # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
-            # - name: ENV_PLATFORM
-            #   value: "aws"
-            - name: DISABLE_TRACING
-              value: "1"
-            - name: DISABLE_PROFILER
-              value: "1"
-          # - name: CYMBAL_BRANDING
-          #   value: "true"
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: frontend
-spec:
-  type: ClusterIP
-  selector:
-    app: frontend
-  ports:
-    - name: http
-      port: 80
-      targetPort: 8000
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: frontend-external
-spec:
-  type: LoadBalancer
-  selector:
-    app: frontend
-  ports:
-    - name: http
-      port: 80
-      targetPort: 8000
+  containers:
+    - image: ashuvduddits/frontend2
+      name: frontend
+      env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "PRODUCT_CATALOG_SERVICE_ADDR:1212"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "CURRENCY-SERVICE-ADDR:1212"
+        - name: CART_SERVICE_ADDR
+          value: "CART-SERVICE-ADDR:1212"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "RECOMMENDATION-SERVICE-ADDR:1212"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "CHECKOUT-SERVICE-ADDR:1212"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "SHIPPING-SERVICE-ADDR:1212"
+        - name: AD_SERVICE_ADDR
+          value: "AD-SERVICE-ADDR:1212"
+      resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/hipster/Dockerfile
+++ b/kubernetes-intro/hipster/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginxinc/nginx-unprivileged:latest
+
+WORKDIR /app
+
+COPY ./frontend/ .
+
+USER 1001
+
+COPY default.conf /etc/nginx/conf.d/

--- a/kubernetes-intro/hipster/default.conf
+++ b/kubernetes-intro/hipster/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen       8008;
+    server_name  localhost;
+
+    location / {
+        root   /app;
+        index  index.html;
+    }
+}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: ashuvduddits/web2
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-web
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginxinc/nginx-unprivileged:latest
+
+WORKDIR /app
+
+COPY . .
+
+USER 1001
+
+COPY default.conf /etc/nginx/conf.d/

--- a/kubernetes-intro/web/default.conf
+++ b/kubernetes-intro/web/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen       8000;
+    server_name  localhost;
+
+    location / {
+        root   /app;
+        index  index.html;
+    }
+}

--- a/kubernetes-intro/web/homework.html
+++ b/kubernetes-intro/web/homework.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+  <h1>Домашняя работа №1</h1>
+</body>
+</html>


### PR DESCRIPTION
# Выполнено ДЗ №1

- [ ] Основное ДЗ
- [ ] Задание со *

## В процессе сделано:
- Разобрался почему все pod в namespace kube-system восстановились после удаления
Поды etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube, kube-scheduler-minikube являются static pods и управляются kubelet на определенных нодах. Манифесты лежат /etc/kubernetes/manifests и перезапускаются они в случае сбоя или удаления по этим манифестам с помощью kubelet.
Как я понял эти правила перезапуска зашиты записаны в этих манифестах. Посмотреть их можно зайдя в minikube ssh.
Поды core-dns и kube-proxy поднимаются из манифестов которые лежат в etcd и соответственно поднимаются после etcd
- Создал Dockerfile, создал образ на базе nginx
- Создал манифест пода web, поднял под в котором 2 контейнера - основной и init и сделал между ними volume чтобы index.html попал в основной контейнер - и после подключения volume то содержимое папки которое я добавлял (homework.html) пропало, ну потому что теперь мы ссылаемся на volume. Как сделать так чтобы и volume был и то что лежало в app сохранилось ???
Проверил работоспособность, получил index.html.
- Склонировал frontend HipsterShop https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/frontend 
- Создал образ на базе nginx (за основу взял Dockerfile для web)
- Выполнил задание со *